### PR TITLE
Fix: Resolved a couple of issues inside of the previously created Workflows

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 jobs:
-  build-and-push-docker-image:
+  publish-package:
     runs-on: ubuntu-latest
     env:
       REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: write
 
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN_SEMANTIC_VERSIONING }}
 
 jobs:
   semantic-versioning:

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.github
+.prettier.json
+.releaserc.json
+typedoc.json
+jest.config.cjs
+babel.config.cjs

--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
     "typedoc": "^0.25.7",
     "typedoc-plugin-markdown": "^3.17.1",
     "typescript": "^5.3.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/EM-Enterprise/HelloCash-API.git"
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the configuration files and package metadata. The most important changes include renaming a job in the publish workflow, adding an environment variable for semantic versioning, updating the `.npmignore` file, and adding repository information to `package.json`.

### Workflow configuration updates:

* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201L13-R13): Renamed the job from `build-and-push-docker-image` to `publish-package`.
* [`.github/workflows/semantic-versioning.yml`](diffhunk://#diff-2e03ee4e8990e529eb053f6703dba8e81e9f64be6d488bee5948c8e96b633b77R12-R13): Added `GH_TOKEN` environment variable to the workflow.

### Package metadata updates:

* [`.npmignore`](diffhunk://#diff-34958b02363eec9a904716f0b4a8782b021c6b33b2e8599019e36c88e045240bR1-R6): Added several configuration files to be ignored by npm.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R39-R42): Added repository information including the type and URL.