### PR TITLE
Fix: Resolves Issues with the Semantic Versioning Workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
-      - name: Publish Package
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Publish Package
+#        run: npm publish
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN_SEMANTIC_VERSIONING }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   semantic-versioning:

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tests.ts
 !.prettierrc.json
 !typedoc.json
 !.releaserc.json
+!.npmrc.json
 
 
 

--- a/.npmrc.json
+++ b/.npmrc.json
@@ -1,0 +1,5 @@
+{
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  }
+}


### PR DESCRIPTION
This pull request includes changes to the workflow and configuration files related to package publishing and semantic versioning. The most important changes include commenting out the publish step in the `publish-package.yml` workflow, adding an NPM token to the semantic versioning workflow, and configuring the npm registry in a new `.npmrc.json` file.

Changes to workflows and configurations:

* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201L32-R35): Commented out the `Publish Package` step to prevent automatic publishing.
* [`.github/workflows/semantic-versioning.yml`](diffhunk://#diff-2e03ee4e8990e529eb053f6703dba8e81e9f64be6d488bee5948c8e96b633b77R14): Added `NPM_TOKEN` to the environment variables to support semantic versioning.
* [`.npmrc.json`](diffhunk://#diff-0073d828c8ec01a718bfee61e4f0ae258c8f14eef9711dfb1879559225714c97R1-R5): Added a new configuration file to specify the npm registry for publishing packages.