### PR TITLE
Fix: Resolving issues with the Semantic Versoning Workflow 

### DIFF
--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,6 +1,10 @@
 name: Automatic Semantic Versioning
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -25,13 +25,12 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Extend .npmrc Configuration
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+      - name: Verify login
+        run: npm whoami --registry=https://npm.pkg.github.com
 
       - name: Run semantice release
         run: |
-          npx semantic-release
+          npm run semantic-release
 
       - name: Print package.json version (before)
         run: |

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,10 +1,6 @@
 name: Automatic Semantic Versioning
 
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+on: push
 
 permissions:
   contents: write

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Install dependencies
         run: yarn
 
+      - name: Extend .npmrc Configuration
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+
       - name: Run semantice release
         run: |
           npx semantic-release

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Verify login
-        run: npm whoami --registry=https://npm.pkg.github.com
-
       - name: Run semantice release
         run: |
           npm run semantic-release

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-registry=https://npm.pkg.github.com/@em-enterprise
-```
+registry=https://npm.pkg.github.com/em-enterprise

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://npm.pkg.github.com/em-enterprise
+@EM-Enterprise:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,2 @@
-{
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  }
-}
+registry=https://npm.pkg.github.com/@em-enterprise
+```

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@EM-Enterprise:registry=https://npm.pkg.github.com
+@em-enterprise:registry=https://npm.pkg.github.com/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,5 +13,5 @@
       ]
     ]
   },
-  "branches": ["main", "master"]
+  "branches": ["main", "master", "workflows"]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,7 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "angular",
+        "preset": "conventionalCommits",
         "releaseRules": [
           { "type": "refactor", "scope": "*", "release": "patch" },
           { "type": "ref", "scope": "*", "release": "patch" },
@@ -21,7 +21,7 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "angular",
+        "preset": "conventionalCommits",
         "presetConfig": {
           "types": [
             { "type": "feat", "section": "Features" },

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,17 +1,15 @@
 {
-  "release": {
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/github",
-      [
-        "@semantic-release/git",
-        {
-          "assets": ["package.json"],
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }
-      ]
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
     ]
-  },
+  ],
   "branches": ["main", "master", "workflows"]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,27 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "refactor", "scope": "*", "release": "patch" },
+          { "type": "ref", "scope": "*", "release": "patch" },
+          { "type": "test", "scope": "*", "release": "patch" },
+          { "type": "tests", "scope": "*", "release": "patch" },
+
+          { "type": "revert", "scope": "*", "release": "patch" },
+          { "type": "docs", "scope": "*", "release": "patch" },
+          { "type": "style", "scope": "*", "release": "patch" },
+          { "type": "chore", "scope": "*", "release": "patch" },
+          { "type": "ci", "scope": "*", "release": "patch" }
+        ]
+      }
+    ],
     [
       "@semantic-release/release-notes-generator",
       {
+        "preset": "angular",
         "presetConfig": {
           "types": [
             { "type": "feat", "section": "Features" },

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,30 @@
 {
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "docs", "section": "Documentation", "hidden": false },
+            { "type": "style", "section": "Styles", "hidden": false },
+            { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
+
+            { "type": "refactor", "section": "Code Refactors", "hidden": false },
+            { "type": "ref", "section": "Code Refactors", "hidden": false },
+
+            { "type": "test", "section": "Tests", "hidden": false },
+            { "type": "tests", "section": "Tests", "hidden": false },
+            { "type": "ci", "section": "CI/CD", "hidden": false }
+          ]
+        }
+      }
+    ],
     "@semantic-release/github",
     [
       "@semantic-release/git",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -24,8 +24,8 @@
         "preset": "conventionalCommits",
         "presetConfig": {
           "types": [
-            { "type": "feat", "section": "Features" },
             { "type": "fix", "section": "Bug Fixes" },
+            { "type": "feat", "section": "Features" },
 
             { "type": "perf", "section": "Performance Improvements" },
             { "type": "revert", "section": "Reverts" },
@@ -33,12 +33,12 @@
             { "type": "style", "section": "Styles", "hidden": false },
             { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
 
-            { "type": "refactor", "section": "Code Refactors", "hidden": false },
-            { "type": "ref", "section": "Code Refactors", "hidden": false },
-
             { "type": "test", "section": "Tests", "hidden": false },
             { "type": "tests", "section": "Tests", "hidden": false },
-            { "type": "ci", "section": "CI/CD", "hidden": false }
+            { "type": "ci", "section": "CI/CD", "hidden": false },
+
+            { "type": "refactor", "section": "Code Refactorings", "hidden": false },
+            { "type": "ref", "section": "Code Refactorings", "hidden": false }
           ]
         }
       }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -52,5 +52,5 @@
       }
     ]
   ],
-  "branches": ["main", "master", "workflows"]
+  "branches": ["main", "master"]
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "ts-node tests",
     "build": "tsc --build tsconfig.json",
-    "prepublishOnly": "tsc --build tsconfig.json  & npm run docs",
+    "prepublishOnly": "tsc --build tsconfig.json",
     "docs": "typedoc --options typedoc.json"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.13",
     "@types/node": "^18.15.11",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "dotenv": "^16.3.1",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@em-enterprise/hellocash-api",
+  "name": "hellocash-api",
   "version": "1.0.5",
   "description": "",
   "main": "dist/index",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "ts-node tests",
     "build": "tsc --build tsconfig.json",
     "prepublishOnly": "tsc --build tsconfig.json",
-    "docs": "typedoc --options typedoc.json"
+    "docs": "typedoc --options typedoc.json",
+    "semantic-release": "semantic-release"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "url": "https://github.com/EM-Enterprise/HelloCash-API.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/EM-Enterprise"
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hellocash-api",
+  "name": "@em-enterprise/hellocash-api",
   "version": "1.0.5",
   "description": "",
   "main": "dist/index",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/EM-Enterprise/HelloCash-API.git"
+    "url": "git+https://github.com/EM-Enterprise/HelloCash-API.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/EM-Enterprise/HelloCash-API.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/EM-Enterprise"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,6 +2470,13 @@ conventional-changelog-angular@^8.0.0:
   dependencies:
     compare-func "^2.0.0"
 
+conventional-changelog-conventionalcommits@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz#3fa2857c878701e7f0329db5a1257cb218f166fe"
+  integrity sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==
+  dependencies:
+    compare-func "^2.0.0"
+
 conventional-changelog-writer@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz#81522ed40400a4ca8ab78a42794aae9667c745ae"


### PR DESCRIPTION
This pull request includes several changes to fix and thereby improve the semantic versioning. The most important changes include updates to the GitHub Actions workflow, the `.npmrc` configuration, the `.releaserc.json` file, and the `package.json` file.

**GitHub Actions Workflow Improvements:**

* Changed the command to run semantic release from `npx semantic-release` to `npm run semantic-release` to align with the updated `package.json` script.

**Configuration Updates:**

* Updated the `.npmrc` file to use a scoped registry configuration for `@em-enterprise` packages.
* Expanded the `.releaserc.json` file to include detailed configuration for `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` with conventional commit presets and custom release rules. [[1]](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L2-R45) [[2]](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L14-R55)

**Package Management Enhancements:**

* Renamed the package in `package.json` to `@em-enterprise/hellocash-api` and added a `semantic-release` script.
* Added `conventional-changelog-conventionalcommits` as a dependency to support conventional commit messages.
* Updated the repository URL and added `publishConfig` to ensure the package is published to the correct registry with public access.