### PR TITLE
CI: Implementation of the NPM Package Publishing Workflow 

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,6 +1,8 @@
 name: Publish NPM Package to GitHub Packages Registry
 
-on: push
+on:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,6 +24,9 @@ jobs:
           node-version: '21'
           registry-url: 'https://npm.pkg.github.com'
 
+      - run: |
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.NPM_TOKEN}}" > .npmrc
+
       - name: Install Dependencies
         run: yarn
 
@@ -31,7 +34,9 @@ jobs:
         id: get_current_release_version
         run: |  
           echo "LATEST_RELEASE_VERSION=$(git ls-remote --tags --sort=committerdate | grep -o 'v.*' | sort -r | head -1)" >> $GITHUB_ENV
-          echo "CLEAN_NEW_VERSION=${LATEST_RELEASE_VERSION#v}" >> $GITHUB_ENV
+
+      - run: |
+          echo "NEW_VERSION=${LATEST_RELEASE_VERSION#v}" >> $GITHUB_ENV
 
 
       - name: Check if Version is Already Published
@@ -40,7 +45,7 @@ jobs:
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           PUBLISHED_VERSIONS=$(npm show "$PACKAGE_NAME" versions --json)
           echo "Published versions: $PUBLISHED_VERSIONS"
-          if echo "$PUBLISHED_VERSIONS" | grep -q "\"${CLEAN_NEW_VERSION}\""; then
+          if echo "$PUBLISHED_VERSIONS" | grep -q "\"${NEW_VERSION}\""; then
             echo "VERSION_ALREADY_PUBLISHED=true" >> $GITHUB_ENV
           else
             echo "VERSION_ALREADY_PUBLISHED=false" >> $GITHUB_ENV
@@ -50,19 +55,19 @@ jobs:
         if: env.VERSION_ALREADY_PUBLISHED == 'false'
         id: set_version
         run: |
-          npm version $NEW_VERSION --no-git-tag-version
-          echo "Increased package version to $NEW_VERSION"
+          npm version ${NEW_VERSION} --no-git-tag-version
+          echo "Increased package version to ${NEW_VERSION}"
 
       - name: Publish Package
         if: env.VERSION_ALREADY_PUBLISHED == 'false'
         run: |
-          echo "Publishing package version ${{ env.NEW_VERSION }}"
+          echo "Publishing package version ${NEW_VERSION}"
           npm publish
 
       - name: Skip Publishing
         if: env.VERSION_ALREADY_PUBLISHED == 'true'
         run: |
-          echo "Package with version $CURRENT_VERSION will not be published as it is already published."
+          echo "Package with version ${NEW_VERSION} will not be published as it is already published."
 
 #      - name: Publish Package
 #        run: npm publish

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -43,8 +43,11 @@ jobs:
         id: check_published
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")
-          PUBLISHED_VERSIONS=$(npm show "$PACKAGE_NAME" versions --json)
+          
+          # Attempt to fetch published versions; handle failure if no versions are published
+          PUBLISHED_VERSIONS=$(npm show "$PACKAGE_NAME" versions --json 2>/dev/null || echo "[]")
           echo "Published versions: $PUBLISHED_VERSIONS"
+          
           if echo "$PUBLISHED_VERSIONS" | grep -q "\"${NEW_VERSION}\""; then
             echo "VERSION_ALREADY_PUBLISHED=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -66,13 +66,3 @@ jobs:
         run: |
           echo "Publishing package version ${NEW_VERSION}"
           npm publish
-
-      - name: Skip Publishing
-        if: env.VERSION_ALREADY_PUBLISHED == 'true'
-        run: |
-          echo "Package with version ${NEW_VERSION} will not be published as it is already published."
-
-#      - name: Publish Package
-#        run: npm publish
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,9 +12,11 @@ permissions:
 jobs:
   publish-package:
     runs-on: ubuntu-latest
+    needs: [semantic-versioning]
+    
     env:
       REPO_NAME: ${{ github.repository }}
-
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -28,6 +30,44 @@ jobs:
 
       - name: Install Dependencies
         run: yarn
+
+      - name: Get latest release version
+        id: get_current_release_version
+        run: |  
+          echo "LATEST_RELEASE_VERSION=$(git ls-remote --tags --sort=committerdate | grep -o 'v.*' | sort -r | head -1)" >> $GITHUB_ENV
+          echo "CLEAN_NEW_VERSION=${LATEST_RELEASE_VERSION#v}" >> $GITHUB_ENV
+
+
+      - name: Check if Version is Already Published
+        if: env.VERSION_CHANGED == 'true'
+        id: check_published
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PUBLISHED_VERSIONS=$(npm show "$PACKAGE_NAME" versions --json)
+          echo "Published versions: $PUBLISHED_VERSIONS"
+          if echo "$PUBLISHED_VERSIONS" | grep -q "\"${CLEAN_NEW_VERSION}\""; then
+            echo "VERSION_ALREADY_PUBLISHED=true" >> $GITHUB_ENV
+          else
+            echo "VERSION_ALREADY_PUBLISHED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Set Package Version
+        if: env.VERSION_ALREADY_PUBLISHED == 'false'
+        id: set_version
+        run: |
+          npm version $NEW_VERSION --no-git-tag-version
+          echo "Increased package version to $NEW_VERSION"
+
+      - name: Publish Package
+        if: env.VERSION_ALREADY_PUBLISHED == 'false'
+        run: |
+          echo "Publishing package version ${{ env.NEW_VERSION }}"
+          npm publish
+
+      - name: Skip Publishing
+        if: env.VERSION_ALREADY_PUBLISHED == 'true'
+        run: |
+          echo "Package with version $CURRENT_VERSION will not be published as it is already published."
 
 #      - name: Publish Package
 #        run: npm publish

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Publish NPM Package to GitHub Packages Registry
 
 on:
   push:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,9 +1,6 @@
 name: Publish NPM Package to GitHub Packages Registry
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 permissions:
   contents: read
@@ -12,7 +9,6 @@ permissions:
 jobs:
   publish-package:
     runs-on: ubuntu-latest
-    needs: [semantic-versioning]
     
     env:
       REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,7 +35,6 @@ jobs:
 
 
       - name: Check if Version is Already Published
-        if: env.VERSION_CHANGED == 'true'
         id: check_published
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")


### PR DESCRIPTION
This pull request includes significant changes to the `publish-package.yml` workflow in order to automate the publishing of an NPM package to the GitHub Packages Registry upon a release event. The most important changes include modifying the trigger event, setting up authentication, and adding steps to check and publish the package version.

Changes to workflow trigger and permissions:

* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201L1-R5): Changed the trigger event from `push` to `release` with types `published`. Updated the workflow name to "Publish NPM Package to GitHub Packages Registry".
* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201R14-R17): Added `NPM_TOKEN` to the environment variables for authentication.

Steps for checking and publishing the package:

* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201R29-R70): Added a step to create an `.npmrc` file with the authentication token.
* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201R29-R70): Added steps to get the latest release version and set the new package version.
* [`.github/workflows/publish-package.yml`](diffhunk://#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201R29-R70): Added steps to check if the version is already published and conditionally publish the package if it is not.