### PR TITLE
CI: Added Semantic Versioning for staging Branch

### DIFF
--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - staging
   workflow_dispatch:
 
 permissions:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -52,5 +52,5 @@
       }
     ]
   ],
-  "branches": ["main", "master"]
+  "branches": ["main", "master", { "name": "staging", "prerelease": true }]
 }


### PR DESCRIPTION
This pull request includes changes to support a new `staging` branch in the workflow and release configuration files.

Workflow configuration:

* [`.github/workflows/semantic-versioning.yml`](diffhunk://#diff-2e03ee4e8990e529eb053f6703dba8e81e9f64be6d488bee5948c8e96b633b77R7): Added the `staging` branch to the list of branches that trigger the workflow on push.

Release configuration:

* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L55-R55): Updated the `branches` array to include the `staging` branch with the `prerelease` attribute set to true.