### PR TITLE
Chore: Rename Branch Staging to Canary for Semantic-Versioning

### DIFF
--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - staging
+      - canary
   workflow_dispatch:
 
 permissions:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -52,5 +52,5 @@
       }
     ]
   ],
-  "branches": ["main", "master", { "name": "staging", "prerelease": true }]
+  "branches": ["main", "master", { "name": "canary", "prerelease": true }]
 }


### PR DESCRIPTION
This pull request includes changes to the branch names used in the CI/CD workflow and release configuration files. The most important changes are:

Branch name updates:

* [`.github/workflows/semantic-versioning.yml`](diffhunk://#diff-2e03ee4e8990e529eb053f6703dba8e81e9f64be6d488bee5948c8e96b633b77L7-R7): Changed the branch name from `staging` to `canary` in the `push` section.
* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L55-R55): Updated the branch name from `staging` to `canary` in the branches configuration.