### PR TITLE
Feat(!): Introduced Package Entrypoint & Improved Package Consumer Imports 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,16 @@
-.github
-.prettier.json
-.releaserc.json
-typedoc.json
-jest.config.cjs
-babel.config.cjs
+## Secrets
+.env
+.actrc
+.github_secrets
+
+*
+
+!/docs/**
+!/dist/**
+!package.json
+!yarn.lock
+!tsconfig.json
+!tsconfig-build.json
+!ReadMe.md
+
+

--- a/.npmignore
+++ b/.npmignore
@@ -10,7 +10,7 @@
 !package.json
 !yarn.lock
 !tsconfig.json
-!tsconfig-build.json
+!tsconfig.build.json
 !ReadMe.md
 
 

--- a/functions/articles/_export.ts
+++ b/functions/articles/_export.ts
@@ -1,0 +1,2 @@
+export { default as getArticles } from '@/functions/articles/getArticles'
+export { default as getArticleStockChanges } from '@/functions/articles/getArticleStockChanges'

--- a/functions/categories/_export.ts
+++ b/functions/categories/_export.ts
@@ -1,0 +1,1 @@
+export { default as getCategories } from '@/functions/categories/getCategories'

--- a/functions/customers/_export.ts
+++ b/functions/customers/_export.ts
@@ -1,0 +1,4 @@
+export { default as getCustomers } from '@/functions/customers/getCustomers'
+export { default as createCustomer } from '@/functions/customers/createCustomer'
+export { default as findCustomer } from '@/functions/customers/findCustomer'
+export { default as findExactCustomer } from '@/functions/customers/findExactCustomer'

--- a/functions/invoices/_export.ts
+++ b/functions/invoices/_export.ts
@@ -1,0 +1,4 @@
+export { getInvoices } from '@/functions/invoices/getInvoices'
+export { default as findInvoiceById } from '@/functions/invoices/findInvoiceById'
+export { default as getBuyHistory } from '@/functions/invoices/getBuyHistory'
+export { default as getInvoiceBase64 } from '@/functions/invoices/getInvoiceBase64'

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,26 @@
+import { setAuthorization } from '@/config/authorization'
+
+import * as invoiceFunctions from '@/functions/invoices/_export'
+import * as customerFunctions from '@/functions/customers/_export'
+import * as articleFunctions from '@/functions/articles/_export'
+import * as categoryFunctions from '@/functions/categories/_export'
+
+type InvoiceFunctionType = typeof invoiceFunctions
+type CustomerFunctionType = typeof customerFunctions
+type ArticleFunctionType = typeof articleFunctions
+type CategoryFunctionType = typeof categoryFunctions
+
+interface Hellocash extends InvoiceFunctionType, CustomerFunctionType, ArticleFunctionType, CategoryFunctionType {}
+
+class Hellocash {
+  constructor(authorizationToken: string) {
+    setAuthorization(authorizationToken)
+
+    Object.assign(this, invoiceFunctions)
+    Object.assign(this, customerFunctions)
+    Object.assign(this, articleFunctions)
+    Object.assign(this, categoryFunctions)
+  }
+}
+
+export default Hellocash

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "ts-node tests",
     "build": "tsc --build tsconfig.build.json && tsc-alias",
     "test": "jest --coverage",
-    "prepublishOnly": "tsc --build tsconfig.json",
+    "prepublishOnly": "npm run build",
     "docs": "typedoc --options typedoc.json",
     "semantic-release": "semantic-release"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.5",
   "description": "",
   "main": "dist/index",
-  "types": "dist/typings/index",
+  "types": "dist/index",
   "scripts": {
     "dev": "ts-node tests",
     "build": "tsc --build tsconfig.build.json && tsc-alias",
@@ -11,6 +11,18 @@
     "prepublishOnly": "npm run build",
     "docs": "typedoc --options typedoc.json",
     "semantic-release": "semantic-release"
+  },
+  "exports": {
+    "./*": {
+      "import": "./dist/*.js",
+      "require": "./dist/*.cjs",
+      "types": "./dist/*.d.ts"
+    },
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,30 @@
     "semantic-release": "semantic-release"
   },
   "exports": {
-    "./*": {
-      "import": "./dist/*.js",
-      "require": "./dist/*.cjs",
-      "types": "./dist/*.d.ts"
+    "./schemas/*": {
+      "import": "./dist/schemas/*.js",
+      "require": "./dist/schemas/*.cjs",
+      "types": "./dist/schemas/*.d.ts"
     },
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./internal/functions/*": {
+      "import": "./dist/functions/*.js",
+      "require": "./dist/functions/*.cjs",
+      "types": "./dist/functions/*.d.ts"
+    },
+    "./internal/config/*": {
+      "import": "./dist/config/*.js",
+      "require": "./dist/config/*.cjs",
+      "types": "./dist/config/*.d.ts"
+    },
+    "./internal/api/*": {
+      "import": "./dist/api/*.js",
+      "require": "./dist/api/*.cjs",
+      "types": "./dist/api/*.d.ts"
     }
   },
   "author": "",

--- a/schemas/article/Article.ts
+++ b/schemas/article/Article.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { useSchema } from '@/schemas/utils/useSchema'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { getRandomNumber, getRandomNumberAsString } from '@/functions/utils/randomDefaultValues'
 
 /**
@@ -23,7 +22,7 @@ export const ArticleSchema = z.object({
   category_id: z.number().optional(),
 })
 
-export type Article = z.infer<StripZodDefault<typeof ArticleSchema>>
+export type Article = z.infer<typeof ArticleSchema>
 
 const { validateObject: validateArticle, getDummyObject: getDummyArticle, safeParseObject: safeParseArticle } = useSchema<Article>(ArticleSchema)
 export { validateArticle, getDummyArticle, safeParseArticle }

--- a/schemas/article/RawArticle.ts
+++ b/schemas/article/RawArticle.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 import { getRandomNumberAsString } from '@/functions/utils/randomDefaultValues'
 
@@ -26,7 +25,7 @@ export const RawArticleSchema = z.object({
   article_stockStatus: z.number().optional().catch(0),
 })
 
-export type RawArticle = z.infer<StripZodDefault<typeof RawArticleSchema>>
+export type RawArticle = z.infer<typeof RawArticleSchema>
 
 const { validateObject: validateRawArticle, getDummyObject: getDummyRawArticle, safeParseObject: safeParseRawArticle } = useSchema<RawArticle>(RawArticleSchema)
 export { validateRawArticle, getDummyRawArticle, safeParseRawArticle }

--- a/schemas/article/RawArticles.ts
+++ b/schemas/article/RawArticles.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { RawArticleSchema } from '@/schemas/article/RawArticle'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -11,7 +10,7 @@ export const RawArticlesSchema = z.object({
   articles: z.array(RawArticleSchema),
 })
 
-export type RawArticles = z.infer<StripZodDefault<typeof RawArticlesSchema>>
+export type RawArticles = z.infer<typeof RawArticlesSchema>
 
 const { validateObject: validateRawArticles, getDummyObject: getDummyRawArticles, safeParseObject: safeParseRawArticles } = useSchema<RawArticles>(RawArticlesSchema)
 export { validateRawArticles, getDummyRawArticles, safeParseRawArticles }

--- a/schemas/article/category/ArticleCategory.ts
+++ b/schemas/article/category/ArticleCategory.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { useSchema } from '@/schemas/utils/useSchema'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 
 /**
  * This schema defines the structure of an article-category object including default values.
@@ -11,7 +10,7 @@ export const ArticleCategorySchema = z.object({
   name: z.string(),
 })
 
-export type ArticleCategory = z.infer<StripZodDefault<typeof ArticleCategorySchema>>
+export type ArticleCategory = z.infer<typeof ArticleCategorySchema>
 
 const { validateObject: validateArticleCategory, getDummyObject: getDummyArticleCategory, safeParseObject: safeParseArticleCategory } = useSchema<ArticleCategory>(ArticleCategorySchema)
 export { validateArticleCategory, getDummyArticleCategory, safeParseArticleCategory }

--- a/schemas/article/category/RawArticleCategories.ts
+++ b/schemas/article/category/RawArticleCategories.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { RawArticleCategorySchema } from '@/schemas/article/category/RawArticleCategory'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -12,7 +11,7 @@ export const RawArticleCategoriesSchema = z.object({
   count: z.number(),
 })
 
-export type RawArticleCategories = z.infer<StripZodDefault<typeof RawArticleCategoriesSchema>>
+export type RawArticleCategories = z.infer<typeof RawArticleCategoriesSchema>
 
 const {
   validateObject: validateRawArticleCategories,

--- a/schemas/article/category/RawArticleCategory.ts
+++ b/schemas/article/category/RawArticleCategory.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -12,7 +11,7 @@ export const RawArticleCategorySchema = z.object({
   article_category_name: z.string(),
 })
 
-export type RawArticleCategory = z.infer<StripZodDefault<typeof RawArticleCategorySchema>>
+export type RawArticleCategory = z.infer<typeof RawArticleCategorySchema>
 
 const { validateObject: validateRawArticleCategory, getDummyObject: getDummyRawArticleCategory, safeParseObject: safeParseRawArticleCategory } = useSchema<RawArticleCategory>(RawArticleCategorySchema)
 export { validateRawArticleCategory, getDummyRawArticleCategory, safeParseRawArticleCategory }

--- a/schemas/article/stock-changes/RawStockChange.ts
+++ b/schemas/article/stock-changes/RawStockChange.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -16,7 +15,7 @@ export const RawStockChangeSchema = z.object({
   stock_description: z.string(),
 })
 
-export type RawStockChange = z.infer<StripZodDefault<typeof RawStockChangeSchema>>
+export type RawStockChange = z.infer<typeof RawStockChangeSchema>
 
 const { validateObject: validateRawStockChange, getDummyObject: getDummyRawStockChange, safeParseObject: safeParseRawStockChange } = useSchema<RawStockChange>(RawStockChangeSchema)
 export { validateRawStockChange, getDummyRawStockChange, safeParseRawStockChange }

--- a/schemas/article/stock-changes/StockChange.ts
+++ b/schemas/article/stock-changes/StockChange.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { useSchema } from '@/schemas/utils/useSchema'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 
 /**
  * This schema defines the structure of a stock-change object including default values.
@@ -16,7 +15,7 @@ export const StockChangeSchema = z.object({
   delivery_number: z.string(),
 })
 
-export type StockChange = z.infer<StripZodDefault<typeof StockChangeSchema>>
+export type StockChange = z.infer<typeof StockChangeSchema>
 
 const { validateObject: validateStockChange, getDummyObject: getDummyStockChange, safeParseObject: safeParseStockChange } = useSchema<StockChange>(StockChangeSchema)
 export { validateStockChange, getDummyStockChange, safeParseStockChange }

--- a/schemas/customer/Customer.ts
+++ b/schemas/customer/Customer.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { getRandomNumberAsString } from '@/functions/utils/randomDefaultValues'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -31,7 +30,7 @@ export const CustomerSchema = z.object({
   notes: z.array(z.string()).default(['Notes']).optional(),
 })
 
-export type Customer = z.infer<StripZodDefault<typeof CustomerSchema>>
+export type Customer = z.infer<typeof CustomerSchema>
 
 const { validateObject: validateCustomer, getDummyObject: getDummyCustomer, safeParseObject: safeParseCustomer } = useSchema<Customer>(CustomerSchema)
 export { validateCustomer, getDummyCustomer, safeParseCustomer }

--- a/schemas/customer/RawCustomer.ts
+++ b/schemas/customer/RawCustomer.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { getRandomNumberAsString } from '@/functions/utils/randomDefaultValues'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -33,7 +32,7 @@ export const RawCustomerSchema = z.object({
   user_custom_fields: z.any(),
 })
 
-export type RawCustomer = z.infer<StripZodDefault<typeof RawCustomerSchema>>
+export type RawCustomer = z.infer<typeof RawCustomerSchema>
 
 const { validateObject: validateRawCustomer, getDummyObject: getDummyRawCustomer, safeParseObject: safeParseRawCustomer } = useSchema<RawCustomer>(RawCustomerSchema)
 export { validateRawCustomer, getDummyRawCustomer, safeParseRawCustomer }

--- a/schemas/customer/RawCustomers.ts
+++ b/schemas/customer/RawCustomers.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 import { RawCustomerSchema } from '@/schemas/customer/RawCustomer'
 
@@ -11,7 +10,7 @@ export const RawCustomersSchema = z.object({
   users: z.array(RawCustomerSchema),
 })
 
-export type RawCustomers = z.infer<StripZodDefault<typeof RawCustomersSchema>>
+export type RawCustomers = z.infer<typeof RawCustomersSchema>
 
 const { validateObject: validateRawCustomers, getDummyObject: getDummyRawCustomers, safeParseObject: safeParseRawCustomers } = useSchema<RawCustomers>(RawCustomersSchema)
 export { validateRawCustomers, getDummyRawCustomers, safeParseRawCustomers }

--- a/schemas/invoice/Invoice.ts
+++ b/schemas/invoice/Invoice.ts
@@ -3,7 +3,6 @@ import { CustomerSchema } from '@/schemas/customer/Customer'
 import { getRandomNumber, getRandomNumberAsString } from '@/functions/utils/randomDefaultValues'
 import { InvoiceItemSchema } from '@/schemas/invoice/InvoiceItem'
 import { useSchema } from '@/schemas/utils/useSchema'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 
 /**
  * This schema defines the structure of an invoice including default values
@@ -20,7 +19,7 @@ export const InvoiceSchema = z.object({
   items: z.array(InvoiceItemSchema),
 })
 
-export type Invoice = z.infer<StripZodDefault<typeof InvoiceSchema>>
+export type Invoice = z.infer<typeof InvoiceSchema>
 
 const { validateObject: validateInvoice, getDummyObject: getDummyInvoice, safeParseObject: safeParseInvoice } = useSchema<Invoice>(InvoiceSchema)
 export { validateInvoice, getDummyInvoice, safeParseInvoice }

--- a/schemas/invoice/InvoiceItem.ts
+++ b/schemas/invoice/InvoiceItem.ts
@@ -1,6 +1,5 @@
 import { getRandomNumber, getRandomNumberAsString } from '@/functions/utils/randomDefaultValues'
 import { z } from 'zod'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -16,7 +15,7 @@ export const InvoiceItemSchema = z.object({
   discount: z.number().default(0),
 })
 
-export type InvoiceItem = z.infer<StripZodDefault<typeof InvoiceItemSchema>>
+export type InvoiceItem = z.infer<typeof InvoiceItemSchema>
 
 const { validateObject: validateInvoiceItem, getDummyObject: getDummyInvoiceItem, safeParseObject: safeParseInvoiceItem } = useSchema<InvoiceItem>(InvoiceItemSchema)
 export { validateInvoiceItem, getDummyInvoiceItem, safeParseInvoiceItem }

--- a/schemas/invoice/RawInvoice.ts
+++ b/schemas/invoice/RawInvoice.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { getRandomNumberAsString } from '@/functions/utils/randomDefaultValues'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 import { useSchema } from '@/schemas/utils/useSchema'
 
 /**
@@ -79,7 +78,7 @@ export const RawInvoiceSchema = z.object({
   ),
 })
 
-export type RawInvoice = z.infer<StripZodDefault<typeof RawInvoiceSchema>>
+export type RawInvoice = z.infer<typeof RawInvoiceSchema>
 
 const { validateObject: validateRawInvoice, getDummyObject: getDummyRawInvoice, safeParseObject: safeParseRawInvoice } = useSchema<RawInvoice>(RawInvoiceSchema)
 export { validateRawInvoice, getDummyRawInvoice, safeParseRawInvoice }

--- a/schemas/invoice/RawInvoices.ts
+++ b/schemas/invoice/RawInvoices.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { RawInvoiceSchema } from '@/schemas/invoice/RawInvoice'
 import { useSchema } from '@/schemas/utils/useSchema'
-import { StripZodDefault } from '@/schemas/utils/stripZodDefaultValues'
 
 /**
  * This schema defines the structure of a raw-invoice including default values
@@ -11,7 +10,7 @@ export const RawInvoicesSchema = z.object({
   invoices: z.array(RawInvoiceSchema),
 })
 
-export type RawInvoices = z.infer<StripZodDefault<typeof RawInvoicesSchema>>
+export type RawInvoices = z.infer<typeof RawInvoicesSchema>
 
 const { validateObject: validateRawInvoices, getDummyObject: getDummyRawInvoices, safeParseObject: safeParseRawInvoices } = useSchema<RawInvoices>(RawInvoicesSchema)
 export { validateRawInvoices, getDummyRawInvoices, safeParseRawInvoices }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "docs", "tests.ts", "custom-api", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*", "**/web/**", "jest.*", "web", "tests", "coverage"]
+  "exclude": ["node_modules", "dist", "docs", "tests", "coverage", "web", "jest.*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "docs", "tests.ts", "custom-api", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*", "**/web/**", "jest.*"]
+  "exclude": ["node_modules", "dist", "docs", "tests.ts", "custom-api", "**/*.test.*", "**/__mocks__/*", "**/__tests__/*", "**/web/**", "jest.*", "web", "tests", "coverage"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
-    "stripInternal": true,
+    "stripInternal": false,
     "noImplicitAny": true,
     "paths": {
       "@/*": ["./*"],


### PR DESCRIPTION
This pull request includes **breaking changes** to the codebase, primarily focusing on the reorganization of exports, the removal of the `StripZodDefault` type, and updates to the `.npmignore` file. The Breaking changes are due to the re-organization of consumer-import paths. This pull request fixes #27. Below are the most important changes:

> Note that consumers must set their `moduleResolution` to Node16 within their tsconfig so that import-paths are resolved correctly!

## Reorganization of Exports

* [`functions/articles/_export.ts`](diffhunk://#diff-ae8cad9ac6fe6fc003c3e7aee69de7e9e4810c5ad3b5632f1fbe25625b156ad0R1-R2): Added exports for `getArticles` and `getArticleStockChanges`.
* [`functions/categories/_export.ts`](diffhunk://#diff-d2f7f7a986e2457fa80b915784b9f8105e0611796c70122d331646ba6c1bfa06R1): Added export for `getCategories`.
* [`functions/customers/_export.ts`](diffhunk://#diff-3899432ab746e011878644db4140edbfb70e81fd9b76cb643ac3f99a55d8c429R1-R4): Added exports for `getCustomers`, `createCustomer`, `findCustomer`, and `findExactCustomer`.
* [`functions/invoices/_export.ts`](diffhunk://#diff-b0507e52f1417e9cfce65c9b6960921d536b4bae63f951edcaca0f8a22a48a10R1-R4): Added exports for `getInvoices`, `findInvoiceById`, `getBuyHistory`, and `getInvoiceBase64`.
* [`index.ts`](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R1-R26): Created a `Hellocash` class that consolidates the functions from invoices, customers, articles, and categories, and sets authorization using the provided token.

## Updates to `.npmignore`

* [`.npmignore`](diffhunk://#diff-34958b02363eec9a904716f0b4a8782b021c6b33b2e8599019e36c88e045240bL1-R16): Updated to exclude everything except for package related implementations, thus no secrets and dev-config files.

## Updates to `package.json`

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R41): Updated the `types` field, modified the `prepublishOnly` script to use the build script, and added an **`exports`** field to improve module resolution for consumers.


### Removal of `StripZodDefault`

* [`schemas/article/Article.ts`](diffhunk://#diff-efe1a09633f27ef310b19ece0bbb6c1b4aadc606bbd3fa2daac59d10d9599a0bL3): Removed `StripZodDefault` and updated the type definition for `Article`. [[1]](diffhunk://#diff-efe1a09633f27ef310b19ece0bbb6c1b4aadc606bbd3fa2daac59d10d9599a0bL3) [[2]](diffhunk://#diff-efe1a09633f27ef310b19ece0bbb6c1b4aadc606bbd3fa2daac59d10d9599a0bL26-R25)
* [`schemas/article/RawArticle.ts`](diffhunk://#diff-4ea3c3d22eea5df4d3d6f749c399bb07e60c6f863e893f9794c1204dacaedad1L2): Removed `StripZodDefault` and updated the type definition for `RawArticle`. [[1]](diffhunk://#diff-4ea3c3d22eea5df4d3d6f749c399bb07e60c6f863e893f9794c1204dacaedad1L2) [[2]](diffhunk://#diff-4ea3c3d22eea5df4d3d6f749c399bb07e60c6f863e893f9794c1204dacaedad1L29-R28)
* [`schemas/article/RawArticles.ts`](diffhunk://#diff-80cbeb761592af4b5b351775450c4156c202d2cfa04faa05d1b27b9c783c870dL3): Removed `StripZodDefault` and updated the type definition for `RawArticles`. [[1]](diffhunk://#diff-80cbeb761592af4b5b351775450c4156c202d2cfa04faa05d1b27b9c783c870dL3) [[2]](diffhunk://#diff-80cbeb761592af4b5b351775450c4156c202d2cfa04faa05d1b27b9c783c870dL14-R13)
* [`schemas/article/category/ArticleCategory.ts`](diffhunk://#diff-16dc8c21b980395a30990c10694ffcfdf49dce9df74311ea5522688c14de7ab1L3): Removed `StripZodDefault` and updated the type definition for `ArticleCategory`. [[1]](diffhunk://#diff-16dc8c21b980395a30990c10694ffcfdf49dce9df74311ea5522688c14de7ab1L3) [[2]](diffhunk://#diff-16dc8c21b980395a30990c10694ffcfdf49dce9df74311ea5522688c14de7ab1L14-R13)
* [`schemas/article/category/RawArticleCategories.ts`](diffhunk://#diff-ee0494bfe2d5c0cee4ea9e6e949712d9427b70c3d8fdae45d44a80cd91cfc60eL3): Removed `StripZodDefault` and updated the type definition for `RawArticleCategories`. [[1]](diffhunk://#diff-ee0494bfe2d5c0cee4ea9e6e949712d9427b70c3d8fdae45d44a80cd91cfc60eL3) [[2]](diffhunk://#diff-ee0494bfe2d5c0cee4ea9e6e949712d9427b70c3d8fdae45d44a80cd91cfc60eL15-R14)
* [`schemas/article/category/RawArticleCategory.ts`](diffhunk://#diff-4c19df5eec5cd4da9e699f765b085bb36cbbe003cdcca470dc3e330cb83d8905L2): Removed `StripZodDefault` and updated the type definition for `RawArticleCategory`. [[1]](diffhunk://#diff-4c19df5eec5cd4da9e699f765b085bb36cbbe003cdcca470dc3e330cb83d8905L2) [[2]](diffhunk://#diff-4c19df5eec5cd4da9e699f765b085bb36cbbe003cdcca470dc3e330cb83d8905L15-R14)
* [`schemas/article/stock-changes/RawStockChange.ts`](diffhunk://#diff-86c522b55b1b3dea191e4ea0755a4b795dd2af0c40187861517afd0dccef5796L2): Removed `StripZodDefault` and updated the type definition for `RawStockChange`. [[1]](diffhunk://#diff-86c522b55b1b3dea191e4ea0755a4b795dd2af0c40187861517afd0dccef5796L2) [[2]](diffhunk://#diff-86c522b55b1b3dea191e4ea0755a4b795dd2af0c40187861517afd0dccef5796L19-R18)
* [`schemas/article/stock-changes/StockChange.ts`](diffhunk://#diff-c39c18f23737905bbe580660f0639151a5511c96970c367f5dfea047c7c31ffdL3): Removed `StripZodDefault` and updated the type definition for `StockChange`. [[1]](diffhunk://#diff-c39c18f23737905bbe580660f0639151a5511c96970c367f5dfea047c7c31ffdL3) [[2]](diffhunk://#diff-c39c18f23737905bbe580660f0639151a5511c96970c367f5dfea047c7c31ffdL19-R18)
* [`schemas/customer/Customer.ts`](diffhunk://#diff-df88846b96d397b83120a7a00607c6b804c108917059149af19e1dc6fa9e032aL3): Removed `StripZodDefault` and updated the type definition for `Customer`. [[1]](diffhunk://#diff-df88846b96d397b83120a7a00607c6b804c108917059149af19e1dc6fa9e032aL3) [[2]](diffhunk://#diff-df88846b96d397b83120a7a00607c6b804c108917059149af19e1dc6fa9e032aL34-R33)
* [`schemas/customer/RawCustomer.ts`](diffhunk://#diff-d0bef54724953919f9ea74a8f573fdfe20ffbc3fa6b453e3f55765a2f5fbc3a0L3): Removed `StripZodDefault` and updated the type definition for `RawCustomer`. [[1]](diffhunk://#diff-d0bef54724953919f9ea74a8f573fdfe20ffbc3fa6b453e3f55765a2f5fbc3a0L3) [[2]](diffhunk://#diff-d0bef54724953919f9ea74a8f573fdfe20ffbc3fa6b453e3f55765a2f5fbc3a0L36-R35)
* [`schemas/customer/RawCustomers.ts`](diffhunk://#diff-84e0d6a49e8ccea32f50c180e451761d72985245c23fe360e8eb3806f31af717L2): Removed `StripZodDefault` and updated the type definition for `RawCustomers`. [[1]](diffhunk://#diff-84e0d6a49e8ccea32f50c180e451761d72985245c23fe360e8eb3806f31af717L2) [[2]](diffhunk://#diff-84e0d6a49e8ccea32f50c180e451761d72985245c23fe360e8eb3806f31af717L14-R13)
* [`schemas/invoice/Invoice.ts`](diffhunk://#diff-f4df89a3e822aecb111b274f51ca62c09aeb0e74f1d457d79943920e98b95df1L6): Removed `StripZodDefault` and updated the type definition for `Invoice`. [[1]](diffhunk://#diff-f4df89a3e822aecb111b274f51ca62c09aeb0e74f1d457d79943920e98b95df1L6) [[2]](diffhunk://#diff-f4df89a3e822aecb111b274f51ca62c09aeb0e74f1d457d79943920e98b95df1L23-R22)
* [`schemas/invoice/InvoiceItem.ts`](diffhunk://#diff-9bf47620f3599095d1174aea37d469662ff8025533e6da4200b7ec229ab9b20bL3): Removed `StripZodDefault` and updated the type definition for `InvoiceItem`. [[1]](diffhunk://#diff-9bf47620f3599095d1174aea37d469662ff8025533e6da4200b7ec229ab9b20bL3) [[2]](diffhunk://#diff-9bf47620f3599095d1174aea37d469662ff8025533e6da4200b7ec229ab9b20bL19-R18)
