### PR TITLE
Fix: Update Export of Hellocash class and type in index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,4 +23,4 @@ class Hellocash {
   }
 }
 
-export default Hellocash
+export = Hellocash


### PR DESCRIPTION
This pull request includes a small change to the `index.ts` file. The change modifies the export statement for the `Hellocash` class to use the `export =` syntax instead of the `export default` syntax.

* [`index.ts`](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L26-R26): Changed the export statement from `export default Hellocash` to `export = Hellocash`. The reason for this change is that previously, importing and instantiating a new class failed for commonjs projects, because 'Hellocash is no constructor'. By changing the export to include both the class and type, consumers are now able to import it as expected.