### PR TITLE
Ref: Updated Publish Documentation worfklow action versions

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 21
         uses: actions/setup-node@v4
@@ -35,10 +35,10 @@ jobs:
 
       - name: Upload Documentation to GitHub Pages
         id: "upload-documentation"
-        uses: "actions/upload-pages-artifact@v2"
+        uses: "actions/upload-pages-artifact@v4"
         with:
           path: "docs/"
 
       - name: Deploy Documentation to GitHub Pages
         id: "deployment"
-        uses: "actions/deploy-pages@v2"
+        uses: "actions/deploy-pages@v4"


### PR DESCRIPTION
> ✅ Description done

This pull request updates the GitHub Actions workflow for publishing documentation. The changes involve upgrading the versions of the actions used in the workflow.

Version updates in `.github/workflows/publish-documentation.yml`:

* Updated `actions/checkout` from `v3` to `v4`.
* Updated `actions/upload-pages-artifact` from `v2` to `v4`.
* Updated `actions/deploy-pages` from `v2` to `v4`.